### PR TITLE
feat: Set port from "--port"  arg in execution script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@
 * Setup your python3 virtual environment using this command ```virtualenv -p python3 venv```
 * Switch to your venv using ```source venv/bin/activate```
 * Now install the required dependencies by running ```pip install -r requirements.txt```
-* Now to run tmessage use ```python msg.py --user [YOUR USERNAME] --server [YOUR BROKER IP OR URL (OPTIONAL)]```
+* Now to run tmessage use ```python msg.py --user [YOUR USERNAME] --port [PORT (optional)] --server [YOUR BROKER IP OR URL (optional)]```
 
-#### NOTE: If you don't want to create your own broker it's perfectly fine as tmessage is using a default broker ```test.mosquitto.org```. Therefore, you can then run tmessage using ```python msg.py --user [YOUR USERNAME]```
+#### NOTE: If you don't want to create your own broker it's perfectly fine as tmessage is using a default broker ```test.mosquitto.org```. Therefore, you can then run tmessage using ```python msg.py --user [YOUR USERNAME]```.
+
+If you happen to use this on a different port, it can be specified as - 
+```python msg.py --user [USERNAME] --port [PORT]```. If omitted, it defaults to 1883.
 
 #### To test this you can open different terminal tabs of course.
 

--- a/msg.py
+++ b/msg.py
@@ -9,12 +9,13 @@ parser = argparse.ArgumentParser(prog='AMU-OSS-MESSAGING',
 # Add the arguments
 parser.add_argument('--user', action='store', type=str, required=True)
 parser.add_argument('--server', action='store', type=str)
+parser.add_argument('--port', action='store', type=int)
 
 args = parser.parse_args()
 
 MQTT_TOPIC = "amu"
 BROKER_ENDPOINT = args.server or "test.mosquitto.org"
-BROKER_PORT = 1883
+BROKER_PORT = args.port or 1883
 
 
 mqtt_client = mqtt.Client()


### PR DESCRIPTION
This enables the user to specify the port number while
executing the main script. If none specified, the default
port is taken to be 1883.
Fixes #7