### PR TITLE
[WIP] Fix pylint errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "3.7"
-before_script: "git clone https://github.com/Shanmugapriya03/tmessage.git"
 install: "pip install -r requirements.txt"
 # command to run tests
 script: pylint **/*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: python
 python:
   - "3.7"
 before_script: "git clone https://github.com/Shanmugapriya03/tmessage.git"
-install: "pip install -r requirements.txt; pylint **/*.py"
+install: "pip install -r requirements.txt"
 # command to run tests
-script: python tests/test.py
+script: pylint **/*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "3.7"
+before_script: "git clone https://github.com/Shanmugapriya03/tmessage.git"
+install: "pip install -r requirements.txt; pylint **/*.py"
+# command to run tests
+script: python tests/test.py

--- a/pylint.yml
+++ b/pylint.yml
@@ -1,0 +1,3 @@
+- name: GitHub Action for pylint
+  uses: cclauss/GitHub-Action-for-pylint@0.7.0
+  args: args = "pip install -r requirements.txt ; pylint **/*.py"

--- a/pylint.yml
+++ b/pylint.yml
@@ -1,3 +1,0 @@
-- name: GitHub Action for pylint
-  uses: cclauss/GitHub-Action-for-pylint@0.7.0
-  args: args = "pip install -r requirements.txt ; pylint **/*.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ paho-mqtt==1.4.0
 requests==2.22.0
 PyJWT==1.7.1
 python-dotenv==0.10.3
+pylint==2.4.2

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import setup
 
 
 def get_requirements():
-    with open('requirements.txt', 'r') as f:
-        raw_requirements = f.readlines()
+    with open('requirements.txt', 'r') as file:
+        raw_requirements = file.readlines()
     requirements = [requirement.strip() for requirement in raw_requirements]
     return requirements
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
+""" Setup for tmessage CLI """
 from setuptools import setup
 
 
 def get_requirements():
+    """ Fetch the requirements from requirements.txt """
     with open('requirements.txt', 'r') as file:
         raw_requirements = file.readlines()
     requirements = [requirement.strip() for requirement in raw_requirements]
@@ -10,7 +12,7 @@ def get_requirements():
 
 setup(name='tmessage',
       entry_points={
-        'console_scripts': ['tmessage=tmessage.cli:main']
+          'console_scripts': ['tmessage=tmessage.cli:main']
       },
       description="""
       This is a lightweight and low bandwidth

--- a/tmessage/auth.py
+++ b/tmessage/auth.py
@@ -8,19 +8,18 @@ API_BASE_URL = os.environ.get("TMESSAGE_API_URL") or "https://peaceful-waters-15
 API_USER_URL = f'{API_BASE_URL}/api/user'
 
 
-def checkExisted(user_name):
-    ENDPOINT_URL = f'{API_USER_URL}/checkExist/{user_name}'
-    response = r.get(ENDPOINT_URL)
+def check_existed(user_name):
+    endpoint_url = f'{API_USER_URL}/checkExist/{user_name}'
+    response = r.get(endpoint_url)
     if response.status_code == 200:
         data = response.json()
         return data['exist']
-    else:
-        error = response.json()
-        raise Exception(f'Error Verifying User: {error["message"]}')
+    error = response.json()
+    raise Exception(f'Error Verifying User: {error["message"]}')
 
 
 def authenticate(user_name, password):
-    ENDPOINT_URL = f'{API_USER_URL}/login'
+    endpoint_url = f'{API_USER_URL}/login'
     headers = {
         "Content-Type": "application/json"
     }
@@ -28,30 +27,28 @@ def authenticate(user_name, password):
         "user_name": user_name,
         "password": password
     }
-    response = r.post(ENDPOINT_URL, json=credential, headers=headers)
+    response = r.post(endpoint_url, json=credential, headers=headers)
     if response.status_code == 200:
         data = response.json()
         return jwt.decode(data['token'], verify=False)
-    else:
-        error = response.json()
-        raise Exception(f'Error Authenticating User: {error["message"]}')
+    error = response.json()
+    raise Exception(f'Error Authenticating User: {error["message"]}')
 
 
 def register(user_name, displayed_name, password, password_confirm):
-    ENDPOINT_URL = f'{API_USER_URL}/register'
+    endpoint_url = f'{API_USER_URL}/register'
     headers = {
         "Content-Type": "application/json"
     }
-    newUser = {
+    new_user = {
         "user_name": user_name,
         "displayed_name": displayed_name,
         "password": password,
         "password_confirm": password_confirm
     }
-    response = r.post(ENDPOINT_URL, json=newUser, headers=headers)
+    response = r.post(endpoint_url, json=new_user, headers=headers)
     if response.status_code == 200:
         data = response.json()
         return jwt.decode(data['token'], verify=False)
-    else:
-        error = response.json()
-        raise Exception(f'Error Registering User: {error["message"]}')
+    error = response.json()
+    raise Exception(f'Error Registering User: {error["message"]}')

--- a/tmessage/auth.py
+++ b/tmessage/auth.py
@@ -1,3 +1,4 @@
+""" Auth : Register new user, check or authenticate existing user """
 import os
 import jwt
 import requests as r
@@ -9,6 +10,7 @@ API_USER_URL = f'{API_BASE_URL}/api/user'
 
 
 def check_existed(user_name):
+    """ Check if  user already exist """
     endpoint_url = f'{API_USER_URL}/checkExist/{user_name}'
     response = r.get(endpoint_url)
     if response.status_code == 200:
@@ -19,6 +21,7 @@ def check_existed(user_name):
 
 
 def authenticate(user_name, password):
+    """ Authenticate already registered User """
     endpoint_url = f'{API_USER_URL}/login'
     headers = {
         "Content-Type": "application/json"
@@ -36,6 +39,7 @@ def authenticate(user_name, password):
 
 
 def register(user_name, displayed_name, password, password_confirm):
+    """ Register a new User """
     endpoint_url = f'{API_USER_URL}/register'
     headers = {
         "Content-Type": "application/json"

--- a/tmessage/cli.py
+++ b/tmessage/cli.py
@@ -1,36 +1,37 @@
-import paho.mqtt.client as mqtt
-import argparse
-from colorama import init, deinit, Fore, Back, Style
-from datetime import datetime
 import os
 import json
+import argparse
+from datetime import datetime
+import paho.mqtt.client as mqtt
+from colorama import init, deinit, Fore, Back, Style
 import tmessage.auth as auth  # auth.py
 
 # Initialize colorama
 init()
 
 # Create the parser
-parser = argparse.ArgumentParser(prog='AMU-OSS-MESSAGING',
+PARSER = argparse.ArgumentParser(prog='AMU-OSS-MESSAGING',
                                  description='cli based group messaging\
                                  for amu-oss sessions',
                                  epilog='Happy learning !')
 
 # Add the arguments
-parser.add_argument('--user', action='store', type=str, required=True)
-parser.add_argument('--server', action='store', type=str)
-parser.add_argument('--port', action='store', type=int)
-parser.add_argument('--dont-store', action='store_false', help='Disables storing of messages.')
+PARSER.add_argument('--user', action='store', type=str, required=True)
+PARSER.add_argument('--server', action='store', type=str)
+PARSER.add_argument('--port', action='store', type=int)
+PARSER.add_argument('--dont-store', action='store_false',
+                    help='Disables storing of messages.')
 
-args = parser.parse_args()
+ARGS = PARSER.parse_args()
 
-IS_STORE = args.dont_store
+IS_STORE = ARGS.dont_store
 MQTT_TOPIC = "amu"
-BROKER_ENDPOINT = args.server or "test.mosquitto.org"
-BROKER_PORT = args.port or 1883
+BROKER_ENDPOINT = ARGS.server or "test.mosquitto.org"
+BROKER_PORT = ARGS.port or 1883
 
 
-mqtt_client = mqtt.Client()
-current_user = args.user
+MQTT_CLIENT = mqtt.Client()
+CURRENT_USER = ARGS.user
 
 
 def on_message(client, userdata, message):
@@ -38,7 +39,7 @@ def on_message(client, userdata, message):
 
     # to get the username between []
     user = current_msg.partition('[')[-1].rpartition(']')[0]
-    if user != current_user:
+    if user != CURRENT_USER:
         print(Back.GREEN + Fore.BLACK + current_msg +
               Back.RESET + Fore.RESET + "")
         _, _, message = current_msg.partition('] ')
@@ -46,31 +47,31 @@ def on_message(client, userdata, message):
             store_messages(user, message)
 
 
-folder_name = 'messages'
-session_start_date = datetime.now().strftime('%Y-%m-%d_%H:%M')
+FOLDER_NAME = 'messages'
+SESSION_START_DATE = datetime.now().strftime('%Y-%m-%d_%H:%M')
 
-data = {}
+DATA = {}
 
 
 def store_messages(user, raw_msg):
-    if not os.path.exists(folder_name):
-        os.mkdir(folder_name)
+    if not os.path.exists(FOLDER_NAME):
+        os.mkdir(FOLDER_NAME)
 
-    data['time'] = datetime.now().strftime('%Y-%m-%d %H:%M')
-    data['content'] = raw_msg
-    data['from'] = user
+    DATA['time'] = datetime.now().strftime('%Y-%m-%d %H:%M')
+    DATA['content'] = raw_msg
+    DATA['from'] = user
 
-    with open('messages/{}.json'.format(session_start_date), 'a', encoding='utf-8') as outfile:
-        json.dump(data, outfile, ensure_ascii=False, indent=4)
+    with open('messages/{}.json'.format(SESSION_START_DATE), 'a', encoding='utf-8') as outfile:
+        json.dump(DATA, outfile, ensure_ascii=False, indent=4)
 
 
 def main():
     try:
-        if auth.checkExisted(current_user):
-            password = input(f'User {current_user} found\nEnter password: ')
-            payload = auth.authenticate(current_user, password)
+        if auth.check_existed(CURRENT_USER):
+            password = input(f'User {CURRENT_USER} found\nEnter password: ')
+            payload = auth.authenticate(CURRENT_USER, password)
         else:
-            print(f'Welcome {current_user} to tmessage!\nPlease register...')
+            print(f'Welcome {CURRENT_USER} to tmessage!\nPlease register...')
             displayed_name = input(f'Enter your name used for display: ')
             password = input(f'Enter password: ')
             password_confirm = input(f'Re-enter password: ')
@@ -78,28 +79,28 @@ def main():
                 print('Passwords do not match, please try again...')
                 password = input(f'Enter password: ')
                 password_confirm = input(f'Re-enter password: ')
-            payload = auth.register(current_user, displayed_name,
+            payload = auth.register(CURRENT_USER, displayed_name,
                                     password, password_confirm)
         print('User Authorized')
         user_name = payload["user_name"]
         displayed_name = payload["displayed_name"]
 
-        mqtt_client.on_message = on_message
-        mqtt_client.connect(BROKER_ENDPOINT, BROKER_PORT)
-        mqtt_client.subscribe(MQTT_TOPIC)
-        mqtt_client.loop_start()
+        MQTT_CLIENT.on_message = on_message
+        MQTT_CLIENT.connect(BROKER_ENDPOINT, BROKER_PORT)
+        MQTT_CLIENT.subscribe(MQTT_TOPIC)
+        MQTT_CLIENT.loop_start()
         while True:
             raw_msg = str(input(Back.RESET + Fore.RESET))
             pub_msg = f'[{user_name}] {displayed_name}: {raw_msg}'
             if raw_msg != '':
-                mqtt_client.publish(MQTT_TOPIC, pub_msg)
+                MQTT_CLIENT.publish(MQTT_TOPIC, pub_msg)
                 if IS_STORE:
-                    store_messages(current_user, raw_msg)
+                    store_messages(CURRENT_USER, raw_msg)
             else:
                 print(Back.WHITE + Fore.RED +
                       "Can't send empty message", end='\n')
     except KeyboardInterrupt:
-        mqtt_client.disconnect()
+        MQTT_CLIENT.disconnect()
         Style.RESET_ALL
         deinit()
         print('\ngoodbye !')

--- a/tmessage/cli.py
+++ b/tmessage/cli.py
@@ -1,3 +1,4 @@
+""" CLI:Register user or auth already registered user to Send, Receive or Store Messages """
 import os
 import json
 import argparse
@@ -35,6 +36,7 @@ CURRENT_USER = ARGS.user
 
 
 def on_message(client, userdata, message):
+    """ callback functions to Process any Messages"""
     current_msg = message.payload.decode("utf-8")
 
     # to get the username between []
@@ -54,6 +56,7 @@ DATA = {}
 
 
 def store_messages(user, raw_msg):
+    """ Store messages in JSON file """
     if not os.path.exists(FOLDER_NAME):
         os.mkdir(FOLDER_NAME)
 
@@ -66,6 +69,7 @@ def store_messages(user, raw_msg):
 
 
 def main():
+    """ Register a new User or Authenticates the already registered User to send message """
     try:
         if auth.check_existed(CURRENT_USER):
             password = input(f'User {CURRENT_USER} found\nEnter password: ')


### PR DESCRIPTION
Issue #34 :
```
************* Module CODE_OF_CONDUCT
CODE_OF_CONDUCT.md:5:0: E0001: invalid syntax (<unknown>, line 5) (syntax-error)
************* Module CONTRIBUTING
CONTRIBUTING.md:3:0: E0001: invalid syntax (<unknown>, line 3) (syntax-error)
************* Module LICENSE
LICENSE:1:0: E0001: unexpected indent (<unknown>, line 1) (syntax-error)
************* Module README
README.md:5:0: E0001: invalid syntax (<unknown>, line 5) (syntax-error)
************* Module requirements
requirements.txt:1:0: E0001: invalid syntax (<unknown>, line 1) (syntax-error)
************* Module setup
setup.py:13:0: C0330: Wrong hanging indentation (add 2 spaces).
        'console_scripts': ['tmessage=tmessage.cli:main']
        ^ | (bad-continuation)
setup.py:1:0: C0111: Missing module docstring (missing-docstring)
setup.py:4:0: C0111: Missing function docstring (missing-docstring)
setup.py:5:42: C0103: Variable name "f" doesn't conform to snake_case naming style (invalid-name)
************* Module tmessage.auth
tmessage/auth.py:1:0: C0111: Missing module docstring (missing-docstring)
tmessage/auth.py:11:0: C0103: Function name "checkExisted" doesn't conform to snake_case naming style (invalid-name)
tmessage/auth.py:11:0: C0111: Missing function docstring (missing-docstring)
tmessage/auth.py:12:4: C0103: Variable name "ENDPOINT_URL" doesn't conform to snake_case naming style (invalid-name)
tmessage/auth.py:14:4: R1705: Unnecessary "else" after "return" (no-else-return)
tmessage/auth.py:22:0: C0111: Missing function docstring (missing-docstring)
tmessage/auth.py:23:4: C0103: Variable name "ENDPOINT_URL" doesn't conform to snake_case naming style (invalid-name)
tmessage/auth.py:32:4: R1705: Unnecessary "else" after "return" (no-else-return)
tmessage/auth.py:40:0: C0111: Missing function docstring (missing-docstring)
tmessage/auth.py:41:4: C0103: Variable name "ENDPOINT_URL" doesn't conform to snake_case naming style (invalid-name)
tmessage/auth.py:45:4: C0103: Variable name "newUser" doesn't conform to snake_case naming style (invalid-name)
tmessage/auth.py:52:4: R1705: Unnecessary "else" after "return" (no-else-return)
************* Module tmessage.cli
tmessage/cli.py:1:0: C0111: Missing module docstring (missing-docstring)
tmessage/cli.py:13:0: C0103: Constant name "parser" doesn't conform to UPPER_CASE naming style (invalid-name)
tmessage/cli.py:24:0: C0103: Constant name "args" doesn't conform to UPPER_CASE naming style (invalid-name)
tmessage/cli.py:32:0: C0103: Constant name "mqtt_client" doesn't conform to UPPER_CASE naming style (invalid-name)
tmessage/cli.py:33:0: C0103: Constant name "current_user" doesn't conform to UPPER_CASE naming style (invalid-name)
tmessage/cli.py:36:0: C0111: Missing function docstring (missing-docstring)
tmessage/cli.py:36:15: W0613: Unused argument 'client' (unused-argument)
tmessage/cli.py:36:23: W0613: Unused argument 'userdata' (unused-argument)
tmessage/cli.py:49:0: C0103: Constant name "folder_name" doesn't conform to UPPER_CASE naming style (invalid-name)
tmessage/cli.py:50:0: C0103: Constant name "session_start_date" doesn't conform to UPPER_CASE naming style (invalid-name)
tmessage/cli.py:52:0: C0103: Constant name "data" doesn't conform to UPPER_CASE naming style (invalid-name)
tmessage/cli.py:55:0: C0111: Missing function docstring (missing-docstring)
tmessage/cli.py:67:0: C0111: Missing function docstring (missing-docstring)
tmessage/cli.py:110:11: W0703: Catching too general exception Exception (broad-except)
tmessage/cli.py:103:8: W0104: Statement seems to have no effect (pointless-statement)
tmessage/cli.py:107:8: W0104: Statement seems to have no effect (pointless-statement)
tmessage/cli.py:111:8: W0104: Statement seems to have no effect (pointless-statement)
tmessage/cli.py:2:0: C0411: standard import "import argparse" should be placed before "import paho.mqtt.client as mqtt" (wrong-import-order)
tmessage/cli.py:4:0: C0411: standard import "from datetime import datetime" should be placed before "import paho.mqtt.client as mqtt" (wrong-import-order)
tmessage/cli.py:5:0: C0411: standard import "import os" should be placed before "import paho.mqtt.client as mqtt" (wrong-import-order)
tmessage/cli.py:6:0: C0411: standard import "import json" should be placed before "import paho.mqtt.client as mqtt" (wrong-import-order)
************* Module tmessage
tmessage.egg-info/__init__.py:1:0: F0010: error while code parsing: Unable to load file tmessage.egg-info/__init__.py:
[Errno 2] No such file or directory: 'tmessage.egg-info/__init__.py' (parse-error)
************* Module venv
venv/__init__.py:1:0: F0010: error while code parsing: Unable to load file venv/__init__.py:
[Errno 2] No such file or directory: 'venv/__init__.py' (parse-error)

------------------------------------------------------------------
Your code has been rated at 5.04/10 
```
[Updated] : Your code has been rated at 10/10 