### PR TITLE
Add Travis CI button to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # tmessage
+[![Build Status](https://travis-ci.com/Haider8/tmessage.svg?branch=master)](https://travis-ci.com/Haider8/tmessage)
 ## This is a lightweight and low bandwidth CLI tool which can be used for group communication right from your terminal (isn't this cool ; ) )
 
 


### PR DESCRIPTION
While working on an issue for this repo, I noticed Travis CI is set up for it but there is no build status button in README. I thought it would be good to have it there and if you guys agree, here it is.